### PR TITLE
Update translate.js 修复日韩包含汉字时被误判为中文

### DIFF
--- a/src/js/translate.js
+++ b/src/js/translate.js
@@ -55,7 +55,9 @@ async function callTranslationAPI(text) {
 
     if (!targetLang) {
       // 如果仍然没有目标语言，根据文本内容判断
-      const hasChinese = /[\u4e00-\u9fa5]/.test(cleanedText);
+      const hasJapanese = /[\u3040-\u309F\u30A0-\u30FF]/.test(cleanedText); // 平假名和片假名
+      const hasKorean = /[\uAC00-\uD7AF]/.test(cleanedText);  // 韩文字母
+      const hasChinese = !hasJapanese && !hasKorean && /[\u4e00-\u9fa5]/.test(cleanedText);// 包含汉字但不含假名和韩文字母时，才视为中文
       targetLang = hasChinese ? "en" : "zh";
     }
 


### PR DESCRIPTION
修改没有目标语言时，中文判断逻辑：包含汉字但不含假名和韩文字母时，才视为中文；而不是包含汉字就视为中文